### PR TITLE
fix: replace iCloud email with custom domain alias

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -72,7 +72,7 @@ export default function AboutPage() {
               variant="outline"
               className="flex items-center gap-2"
             >
-              <a href="mailto:n_cole_summers@icloud.com">
+              <a href="mailto:nate@ncolesummers.com">
                 <Mail className="h-4 w-4" />
                 Email
               </a>
@@ -250,7 +250,7 @@ export default function AboutPage() {
           </p>
           <div className="flex justify-center gap-4">
             <Button asChild variant="accent">
-              <a href="mailto:n_cole_summers@icloud.com">Get in Touch</a>
+              <a href="mailto:nate@ncolesummers.com">Get in Touch</a>
             </Button>
             <Button asChild variant="outline">
               <Link href="/">View My Work</Link>

--- a/src/app/projects/uidaho-website/page.tsx
+++ b/src/app/projects/uidaho-website/page.tsx
@@ -179,9 +179,8 @@ export default function UIdahoWebsitePage() {
                   </ListItem>
                   <ListItem>
                     <strong className="mr-1">Azure Integration:</strong>
-                    Implemented Azure Blob Storage for Anonymized Poll Data
-                    management and created serverless functions for storage and
-                    analytics.
+                    Implemented Azure Blob Storage for anonymized poll data and
+                    created serverless functions for dynamic content delivery.
                   </ListItem>
                   <ListItem>
                     <strong className="mr-1">Performance Optimization:</strong>

--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -10,7 +10,7 @@ const ContactSection = () => {
         <p className="mb-8 text-sm sm:text-base md:text-lg text-gray-400">
           I&apos;m open to new opportunities and would love to hear from you.
         </p>
-        <a href="mailto:n_cole_summers@icloud.com">
+        <a href="mailto:nate@ncolesummers.com">
           <Button className="bg-white text-black hover:bg-gray-200">
             Contact me
           </Button>


### PR DESCRIPTION
## Summary
- Replace `n_cole_summers@icloud.com` with `nate@ncolesummers.com` across all `mailto:` links
- Update uidaho-website project copy for Azure integration description

## Motivation
The iCloud address was exposed in a public repo, making it a target for spam scrapers. The custom domain alias keeps the real inbox private and is easier to rotate if needed.

## Files Changed
- `src/components/contact-section.tsx`
- `src/app/about/page.tsx` (3 occurrences)
- `src/app/projects/uidaho-website/page.tsx` (copy edit)

## Test plan
- [ ] Verify mailto links open correct address in browser
- [ ] Confirm no remaining references to old iCloud address

🤖 Generated with [Claude Code](https://claude.com/claude-code)