### PR TITLE
update: Instagram URL and stage name to dunder style

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -11,7 +11,7 @@ const Header = () => {
           className="text-lg font-bold tracking-tight sm:tracking-normal"
           href="/"
         >
-          n_cole_summers
+          n__cole__summers
         </Link>
         <div className="flex items-center gap-4">
           <div>

--- a/src/lib/const.ts
+++ b/src/lib/const.ts
@@ -33,6 +33,6 @@ export const Socials = [
   },
   {
     name: "Instagram",
-    href: "https://www.instagram.com/ncolesummers/",
+    href: "https://www.instagram.com/n__cole__summers/",
   },
 ];

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -113,7 +113,7 @@ test.describe("Navigation", () => {
       await expect(page.locator("header")).toBeVisible();
 
       // Should be able to navigate back to home
-      await page.click("text=n_cole_summers"); // Logo/name link
+      await page.click("text=n__cole__summers"); // Logo/name link
       await expect(page).toHaveURL("/");
     });
   });


### PR DESCRIPTION
## Summary
- Updated Instagram social link to new handle: `n__cole__summers`
- Changed displayed stage name from `n_cole_summers` to `n__cole__summers` in the header
- Updated E2E test selector to match new stage name

## Test plan
- [x] `pnpm lint` — zero errors
- [x] `pnpm build` — successful
- [x] `pnpm test:e2e` — 192 passed, 1 skipped (manual integration)
- [ ] Visual check: header displays `n__cole__summers`
- [ ] Instagram icon links to `https://www.instagram.com/n__cole__summers/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)