### PR TITLE
feat: add Enterprise Agent Development Lifecycle project page

### DIFF
--- a/src/app/projects/agent-development-lifecycle/page.tsx
+++ b/src/app/projects/agent-development-lifecycle/page.tsx
@@ -44,16 +44,16 @@ export default function AgentDevelopmentLifecyclePage() {
             a production-grade implementation built on the Claude Agent SDK
           </p>
           <div className="flex gap-4">
-            <a
-              href="https://github.com/ncolesummers/enterprise-agent-development-lifecycle"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Button variant="outline" className="gap-2">
+            <Button variant="outline" className="gap-2" asChild>
+              <a
+                href="https://github.com/ncolesummers/enterprise-agent-development-lifecycle"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 <ExternalLink className="h-4 w-4" />
                 View on GitHub
-              </Button>
-            </a>
+              </a>
+            </Button>
           </div>
           <div className="mt-8 flex flex-wrap justify-center gap-2">
             <span className="rounded-md bg-muted px-2 py-1 text-sm">
@@ -415,19 +415,19 @@ const report = EvaluationReportSchema.parse(data);`}
             available on GitHub.
           </p>
           <div className="flex justify-center gap-4">
-            <a
-              href="https://github.com/ncolesummers/enterprise-agent-development-lifecycle"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <Button variant="outline" className="gap-2">
+            <Button variant="outline" className="gap-2" asChild>
+              <a
+                href="https://github.com/ncolesummers/enterprise-agent-development-lifecycle"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 <ExternalLink className="h-4 w-4" />
                 View on GitHub
-              </Button>
-            </a>
-            <Link href="/#contact">
-              <Button variant="accent">Contact Me</Button>
-            </Link>
+              </a>
+            </Button>
+            <Button variant="accent" asChild>
+              <Link href="/#contact">Contact Me</Link>
+            </Button>
           </div>
         </section>
       </main>

--- a/src/app/projects/agent-development-lifecycle/page.tsx
+++ b/src/app/projects/agent-development-lifecycle/page.tsx
@@ -1,0 +1,438 @@
+import { Button } from "@/components/ui/button";
+import { ArrowLeft, ExternalLink } from "lucide-react";
+import Link from "next/link";
+import ContentCard from "@/components/ui/content-card";
+import BulletedList, { ListItem } from "@/components/ui/bulleted-list";
+import CodeBlock from "@/components/ui/code-block";
+import Section from "@/components/ui/section";
+import Image from "next/image";
+import { generatePageMetadata } from "@/lib/metadata";
+import Footer from "@/components/footer";
+import ArchitectureDiagram from "@/assets/adlc-architecture.svg";
+
+export const metadata = generatePageMetadata({
+  title: "Enterprise Agent Development Lifecycle",
+  description:
+    "A TypeScript reference architecture for multi-agent autonomous coding systems built on Anthropic's Claude Agent SDK. GAN-inspired three-agent orchestration with file-based state management and OpenTelemetry observability.",
+  path: "/projects/agent-development-lifecycle",
+});
+
+export default function AgentDevelopmentLifecyclePage() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <header className="sticky top-0 z-50 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 px-4">
+        <div className="container flex h-14 items-center">
+          <Link
+            href="/"
+            className="flex items-center gap-2 text-sm hover:text-muted-foreground transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to Home
+          </Link>
+        </div>
+      </header>
+
+      <main className="container py-12 px-4">
+        {/* Hero Section */}
+        <div className="mb-16 flex flex-col items-center text-center">
+          <h1 className="mb-6 text-4xl font-bold tracking-tighter md:text-6xl">
+            Enterprise Agent Development Lifecycle
+          </h1>
+          <p className="mb-8 max-w-2xl text-xl text-muted-foreground">
+            A TypeScript reference architecture for multi-agent autonomous coding
+            systems, synthesizing five Anthropic research documents into a
+            production-grade implementation built on the Claude Agent SDK
+          </p>
+          <div className="flex gap-4">
+            <a
+              href="https://github.com/ncolesummers/enterprise-agent-development-lifecycle"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button variant="outline" className="gap-2">
+                <ExternalLink className="h-4 w-4" />
+                View on GitHub
+              </Button>
+            </a>
+          </div>
+          <div className="mt-8 flex flex-wrap justify-center gap-2">
+            <span className="rounded-md bg-muted px-2 py-1 text-sm">
+              TypeScript
+            </span>
+            <span className="rounded-md bg-muted px-2 py-1 text-sm">Bun</span>
+            <span className="rounded-md bg-muted px-2 py-1 text-sm">
+              Claude Agent SDK
+            </span>
+            <span className="rounded-md bg-muted px-2 py-1 text-sm">Zod</span>
+            <span className="rounded-md bg-muted px-2 py-1 text-sm">
+              OpenTelemetry
+            </span>
+            <span className="rounded-md bg-muted px-2 py-1 text-sm">
+              Commander
+            </span>
+            <span className="rounded-md bg-muted px-2 py-1 text-sm">
+              Biome
+            </span>
+          </div>
+        </div>
+
+        {/* Research Foundation */}
+        <Section title="Research Foundation">
+          <div className="grid gap-8 md:grid-cols-2">
+            <div>
+              <p className="mb-4 text-lg text-muted-foreground">
+                Anthropic published a series of research documents on building
+                effective harnesses for long-running autonomous coding agents.
+                The reference implementations and quickstart examples are
+                exclusively Python SDK, leaving the broader Node.js and
+                TypeScript ecosystem without a production-grade equivalent.
+              </p>
+              <p className="mb-4 text-lg text-muted-foreground">
+                This project translates those patterns to TypeScript and Bun,
+                making the architectural insights accessible to teams already
+                operating in the JavaScript ecosystem. The core problem these
+                documents address is the{" "}
+                <strong>context window gap</strong> — even frontier models fail
+                at production-quality builds because compaction alone is not
+                sufficient for multi-session work.
+              </p>
+              <p className="text-lg text-muted-foreground">
+                Two critical failure modes emerge in practice:{" "}
+                <strong>over-ambition</strong>, where the agent exhausts its
+                context window mid-feature and produces incomplete work, and{" "}
+                <strong>premature completion</strong>, where the agent declares
+                victory despite incomplete requirements. The architecture
+                addresses both through structured state management and separated
+                evaluation.
+              </p>
+            </div>
+            <ContentCard>
+              <h3 className="mb-4 text-xl font-semibold">Source Research</h3>
+              <BulletedList>
+                <ListItem>
+                  <strong>&quot;Effective Harnesses for Long-Running
+                  Agents&quot;</strong>{" "}
+                  (Nov 2025) — Two-agent pattern, feature list as source of
+                  truth, progress tracking, boot sequence
+                </ListItem>
+                <ListItem>
+                  <strong>&quot;Harness Design for Long-Running Application
+                  Development&quot;</strong>{" "}
+                  (Mar 2026) — GAN-inspired three-agent architecture, context
+                  anxiety, self-evaluation bias, four grading criteria
+                </ListItem>
+                <ListItem>
+                  <strong>Autonomous Coding Quickstart</strong> (GitHub) — Python
+                  reference implementation with session management, security
+                  model, and browser automation
+                </ListItem>
+                <ListItem>
+                  <strong>Claude Code Hooks Multi-Agent Observability</strong>
+                  {" "}(GitHub) — Hook-to-event mapping, real-time monitoring
+                  patterns, security hooks
+                </ListItem>
+                <ListItem>
+                  <strong>Claude Code Native OTel Monitoring</strong> — Built-in
+                  telemetry export, available metrics and events, per-session
+                  correlation
+                </ListItem>
+              </BulletedList>
+            </ContentCard>
+          </div>
+        </Section>
+
+        {/* Architecture */}
+        <Section title="Architecture">
+          <div className="mb-8 overflow-hidden rounded-lg bg-card">
+            <div className="relative w-full h-64 md:h-80 lg:h-96 bg-card">
+              <Image
+                src={ArchitectureDiagram}
+                alt="Architecture diagram showing the three-agent orchestration pipeline: Initializer, Generator, and Evaluator"
+                className="object-contain"
+                fill
+                sizes="(max-width: 768px) 100vw, (max-width: 1024px) 80vw, 60vw"
+              />
+            </div>
+          </div>
+
+          <ContentCard className="mb-8">
+            <h3 className="mb-4 text-xl font-semibold">
+              GAN-Inspired Three-Agent Orchestration
+            </h3>
+            <p className="mb-4 text-muted-foreground">
+              The architecture draws from the adversarial dynamic in generative
+              adversarial networks: a generator produces work, and an
+              independent evaluator judges it. A third agent handles
+              initialization, creating the structured inputs that drive the
+              entire lifecycle.
+            </p>
+            <ol className="space-y-4 text-muted-foreground">
+              <li className="flex items-start">
+                <span className="mr-2 font-bold">1.</span>
+                <div>
+                  <strong>Initializer</strong> — Reads the application
+                  specification, generates a comprehensive feature list as JSON
+                  (not Markdown — the model is less likely to inappropriately
+                  change JSON), scaffolds the project structure, and creates a
+                  repeatable bootstrap script.
+                </div>
+              </li>
+              <li className="flex items-start">
+                <span className="mr-2 font-bold">2.</span>
+                <div>
+                  <strong>Generator</strong> — Implements exactly one feature per
+                  session following a prescribed boot sequence: verify working
+                  directory, read progress, check git log, run init script,
+                  confirm baseline, then implement. One-feature-per-session
+                  discipline prevents context exhaustion.
+                </div>
+              </li>
+              <li className="flex items-start">
+                <span className="mr-2 font-bold">3.</span>
+                <div>
+                  <strong>Evaluator</strong> — Tests the running application
+                  independently using browser automation. Scores against four
+                  criteria: design quality, originality, craft, and
+                  functionality. A separated evaluator overcomes self-evaluation
+                  bias — tuning a standalone evaluator to be skeptical is far
+                  more tractable than making a generator critical of its own
+                  work.
+                </div>
+              </li>
+            </ol>
+          </ContentCard>
+
+          <div className="grid gap-8 md:grid-cols-2">
+            <ContentCard>
+              <h3 className="mb-4 text-xl font-semibold">State Machine</h3>
+              <CodeBlock title="Orchestration States">
+                {`needs_initialization
+  → needs_planning
+    → needs_generation
+      → needs_evaluation
+        → complete`}
+              </CodeBlock>
+              <p className="mt-4 text-muted-foreground">
+                The orchestrator uses state detection to determine which agent to
+                dispatch next. File-based state survives context resets,
+                providing clean handoffs between sessions.
+              </p>
+            </ContentCard>
+            <ContentCard>
+              <h3 className="mb-4 text-xl font-semibold">
+                Key Design Decisions
+              </h3>
+              <BulletedList>
+                <ListItem>
+                  Feature list uses JSON (not Markdown) to prevent agent
+                  over-editing
+                </ListItem>
+                <ListItem>
+                  One feature per session prevents context exhaustion and
+                  over-ambition
+                </ListItem>
+                <ListItem>
+                  Separated evaluator overcomes self-evaluation bias
+                </ListItem>
+                <ListItem>
+                  File-based inter-agent communication with Zod-validated JSON
+                  schemas
+                </ListItem>
+                <ListItem>
+                  Atomic file writes with temp files and rename prevent
+                  corruption
+                </ListItem>
+                <ListItem>
+                  Cost and duration tracking per session for ROI analysis
+                </ListItem>
+              </BulletedList>
+            </ContentCard>
+          </div>
+        </Section>
+
+        {/* Technical Implementation */}
+        <Section title="Technical Implementation">
+          <div className="grid gap-8 md:grid-cols-2">
+            <ContentCard>
+              <h3 className="mb-4 text-xl font-semibold">
+                Runtime Validation
+              </h3>
+              <p className="mb-4 text-muted-foreground">
+                Every agent communication boundary is protected by Zod schema
+                validation. State files are validated at both read and write,
+                ensuring agents cannot create malformed state or silently corrupt
+                the shared coordination layer.
+              </p>
+              <CodeBlock title="Zod Schema Validation">
+                {`// Every state file is validated at read and write
+const features = FeatureListSchema.parse(
+  JSON.parse(await Bun.file(path).text())
+);
+
+// Agents can't create malformed state
+const report = EvaluationReportSchema.parse(data);`}
+              </CodeBlock>
+              <p className="mt-4 text-muted-foreground">
+                Runtime validation catches schema drift and ensures agents
+                can&apos;t accidentally corrupt the shared state that
+                coordinates multi-session work.
+              </p>
+            </ContentCard>
+            <ContentCard>
+              <h3 className="mb-4 text-xl font-semibold">Observability</h3>
+              <p className="mb-4 text-muted-foreground">
+                The observability strategy uses two complementary layers of
+                OpenTelemetry instrumentation to provide full visibility across
+                the agent lifecycle.
+              </p>
+              <BulletedList>
+                <ListItem>
+                  <strong>Layer 1 (Native):</strong> Claude Code&apos;s built-in
+                  telemetry — session counts, token usage, cost per model, lines
+                  of code modified, tool decisions
+                </ListItem>
+                <ListItem>
+                  <strong>Layer 2 (Harness):</strong> Custom spans connecting
+                  multi-agent sessions into coherent traces, aggregated metrics
+                  across the full orchestration lifecycle
+                </ListItem>
+              </BulletedList>
+            </ContentCard>
+          </div>
+          <ContentCard className="mt-8">
+            <h3 className="mb-4 text-xl font-semibold">Developer Experience</h3>
+            <BulletedList>
+              <ListItem>
+                CLI interface with Commander for both interactive and automated
+                operation
+              </ListItem>
+              <ListItem>
+                Biome for code quality enforcement via SDK hooks — commits
+                blocked on lint errors
+              </ListItem>
+              <ListItem>
+                Security model with bash command allowlist restricting agent
+                access to safe operations
+              </ListItem>
+              <ListItem>
+                Bun runtime for native TypeScript execution without
+                transpilation and fast startup
+              </ListItem>
+              <ListItem>
+                Configuration file support with CLI argument overrides
+              </ListItem>
+            </BulletedList>
+          </ContentCard>
+        </Section>
+
+        {/* Context Window Strategy */}
+        <Section title="Context Window Strategy">
+          <ContentCard>
+            <div className="grid gap-8 md:grid-cols-2">
+              <div>
+                <p className="mb-4 text-lg text-muted-foreground">
+                  Long-running agents face{" "}
+                  <strong>context anxiety</strong> — models begin wrapping up
+                  work prematurely as they approach what they believe is their
+                  context limit. This manifests as rushing through
+                  implementation, cutting corners, and declaring victory early.
+                </p>
+                <p className="mb-4 text-lg text-muted-foreground">
+                  Context resets (clearing the window entirely) proved more
+                  effective than compaction (summarizing in-place) for models
+                  exhibiting this behavior. The architecture solves this by
+                  encoding all progress into structured files that survive
+                  window resets, so no institutional knowledge is lost when the
+                  context is cleared.
+                </p>
+              </div>
+              <div>
+                <h3 className="mb-4 text-xl font-semibold">
+                  Architectural Solutions
+                </h3>
+                <BulletedList>
+                  <ListItem>
+                    <code>feature_list.json</code> as single source of truth —
+                    agents may only modify the <code>passes</code> field
+                  </ListItem>
+                  <ListItem>
+                    <code>progress.json</code> for institutional memory across
+                    sessions
+                  </ListItem>
+                  <ListItem>
+                    <code>evaluation_report.json</code> with structured scores
+                    and actionable feedback
+                  </ListItem>
+                  <ListItem>
+                    Boot sequence saves tokens by prescribing startup steps
+                    every session
+                  </ListItem>
+                  <ListItem>
+                    Git history with descriptive commits enables agents to
+                    revert failed changes
+                  </ListItem>
+                </BulletedList>
+              </div>
+            </div>
+          </ContentCard>
+        </Section>
+
+        {/* Project Validation */}
+        <Section title="Project Validation">
+          <div className="grid gap-8 md:grid-cols-2">
+            <div className="rounded-lg bg-card p-6">
+              <h3 className="mb-4 text-xl font-semibold">
+                Phase 1: Hello World
+              </h3>
+              <p className="text-lg text-muted-foreground">
+                Validates the full agent stack end-to-end with a simple HTTP
+                server. Tests the complete lifecycle: initialization generates
+                the feature list and scaffolds the project, the generator
+                implements features one at a time with proper commits, and the
+                evaluator verifies the running application via browser
+                automation.
+              </p>
+            </div>
+            <div className="rounded-lg bg-card p-6">
+              <h3 className="mb-4 text-xl font-semibold">
+                Phase 2: TeamDynamix MCP Server
+              </h3>
+              <p className="text-lg text-muted-foreground">
+                An MCP server wrapping the TeamDynamix REST API, currently in
+                design phase. Demonstrates the architecture&apos;s applicability
+                to real-world enterprise tooling — exposing ticket search,
+                creation, and updates as MCP tools with Zod-validated schemas
+                for API responses.
+              </p>
+            </div>
+          </div>
+        </Section>
+
+        {/* Call to Action */}
+        <section className="text-center">
+          <h2 className="mb-6 text-3xl font-bold">Explore the Architecture</h2>
+          <p className="mb-8 text-lg text-muted-foreground max-w-2xl mx-auto">
+            The full source code, documentation, and reference architecture are
+            available on GitHub.
+          </p>
+          <div className="flex justify-center gap-4">
+            <a
+              href="https://github.com/ncolesummers/enterprise-agent-development-lifecycle"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button variant="outline" className="gap-2">
+                <ExternalLink className="h-4 w-4" />
+                View on GitHub
+              </Button>
+            </a>
+            <Link href="/#contact">
+              <Button variant="accent">Contact Me</Button>
+            </Link>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/projects/agent-development-lifecycle/page.tsx
+++ b/src/app/projects/agent-development-lifecycle/page.tsx
@@ -39,9 +39,9 @@ export default function AgentDevelopmentLifecyclePage() {
             Enterprise Agent Development Lifecycle
           </h1>
           <p className="mb-8 max-w-2xl text-xl text-muted-foreground">
-            A TypeScript reference architecture for multi-agent autonomous coding
-            systems, synthesizing five Anthropic research documents into a
-            production-grade implementation built on the Claude Agent SDK
+            A TypeScript reference architecture for multi-agent autonomous
+            coding systems, synthesizing five Anthropic research documents into
+            a production-grade implementation built on the Claude Agent SDK
           </p>
           <div className="flex gap-4">
             <a
@@ -70,9 +70,7 @@ export default function AgentDevelopmentLifecyclePage() {
             <span className="rounded-md bg-muted px-2 py-1 text-sm">
               Commander
             </span>
-            <span className="rounded-md bg-muted px-2 py-1 text-sm">
-              Biome
-            </span>
+            <span className="rounded-md bg-muted px-2 py-1 text-sm">Biome</span>
           </div>
         </div>
 
@@ -91,10 +89,9 @@ export default function AgentDevelopmentLifecyclePage() {
                 This project translates those patterns to TypeScript and Bun,
                 making the architectural insights accessible to teams already
                 operating in the JavaScript ecosystem. The core problem these
-                documents address is the{" "}
-                <strong>context window gap</strong> — even frontier models fail
-                at production-quality builds because compaction alone is not
-                sufficient for multi-session work.
+                documents address is the <strong>context window gap</strong> —
+                even frontier models fail at production-quality builds because
+                compaction alone is not sufficient for multi-session work.
               </p>
               <p className="text-lg text-muted-foreground">
                 Two critical failure modes emerge in practice:{" "}
@@ -110,25 +107,28 @@ export default function AgentDevelopmentLifecyclePage() {
               <h3 className="mb-4 text-xl font-semibold">Source Research</h3>
               <BulletedList>
                 <ListItem>
-                  <strong>&quot;Effective Harnesses for Long-Running
-                  Agents&quot;</strong>{" "}
+                  <strong>
+                    &quot;Effective Harnesses for Long-Running Agents&quot;
+                  </strong>{" "}
                   (Nov 2025) — Two-agent pattern, feature list as source of
                   truth, progress tracking, boot sequence
                 </ListItem>
                 <ListItem>
-                  <strong>&quot;Harness Design for Long-Running Application
-                  Development&quot;</strong>{" "}
+                  <strong>
+                    &quot;Harness Design for Long-Running Application
+                    Development&quot;
+                  </strong>{" "}
                   (Mar 2026) — GAN-inspired three-agent architecture, context
                   anxiety, self-evaluation bias, four grading criteria
                 </ListItem>
                 <ListItem>
-                  <strong>Autonomous Coding Quickstart</strong> (GitHub) — Python
-                  reference implementation with session management, security
-                  model, and browser automation
+                  <strong>Autonomous Coding Quickstart</strong> (GitHub) —
+                  Python reference implementation with session management,
+                  security model, and browser automation
                 </ListItem>
                 <ListItem>
-                  <strong>Claude Code Hooks Multi-Agent Observability</strong>
-                  {" "}(GitHub) — Hook-to-event mapping, real-time monitoring
+                  <strong>Claude Code Hooks Multi-Agent Observability</strong>{" "}
+                  (GitHub) — Hook-to-event mapping, real-time monitoring
                   patterns, security hooks
                 </ListItem>
                 <ListItem>
@@ -180,11 +180,12 @@ export default function AgentDevelopmentLifecyclePage() {
               <li className="flex items-start">
                 <span className="mr-2 font-bold">2.</span>
                 <div>
-                  <strong>Generator</strong> — Implements exactly one feature per
-                  session following a prescribed boot sequence: verify working
-                  directory, read progress, check git log, run init script,
-                  confirm baseline, then implement. One-feature-per-session
-                  discipline prevents context exhaustion.
+                  <strong>Generator</strong> — Implements exactly one feature
+                  per session following a prescribed boot sequence: verify
+                  working directory, read progress, check git log, run init
+                  script, confirm baseline, then implement.
+                  One-feature-per-session discipline prevents context
+                  exhaustion.
                 </div>
               </li>
               <li className="flex items-start">
@@ -213,8 +214,8 @@ export default function AgentDevelopmentLifecyclePage() {
         → complete`}
               </CodeBlock>
               <p className="mt-4 text-muted-foreground">
-                The orchestrator uses state detection to determine which agent to
-                dispatch next. File-based state survives context resets,
+                The orchestrator uses state detection to determine which agent
+                to dispatch next. File-based state survives context resets,
                 providing clean handoffs between sessions.
               </p>
             </ContentCard>
@@ -254,14 +255,12 @@ export default function AgentDevelopmentLifecyclePage() {
         <Section title="Technical Implementation">
           <div className="grid gap-8 md:grid-cols-2">
             <ContentCard>
-              <h3 className="mb-4 text-xl font-semibold">
-                Runtime Validation
-              </h3>
+              <h3 className="mb-4 text-xl font-semibold">Runtime Validation</h3>
               <p className="mb-4 text-muted-foreground">
                 Every agent communication boundary is protected by Zod schema
                 validation. State files are validated at both read and write,
-                ensuring agents cannot create malformed state or silently corrupt
-                the shared coordination layer.
+                ensuring agents cannot create malformed state or silently
+                corrupt the shared coordination layer.
               </p>
               <CodeBlock title="Zod Schema Validation">
                 {`// Every state file is validated at read and write
@@ -331,11 +330,11 @@ const report = EvaluationReportSchema.parse(data);`}
             <div className="grid gap-8 md:grid-cols-2">
               <div>
                 <p className="mb-4 text-lg text-muted-foreground">
-                  Long-running agents face{" "}
-                  <strong>context anxiety</strong> — models begin wrapping up
-                  work prematurely as they approach what they believe is their
-                  context limit. This manifests as rushing through
-                  implementation, cutting corners, and declaring victory early.
+                  Long-running agents face <strong>context anxiety</strong> —
+                  models begin wrapping up work prematurely as they approach
+                  what they believe is their context limit. This manifests as
+                  rushing through implementation, cutting corners, and declaring
+                  victory early.
                 </p>
                 <p className="mb-4 text-lg text-muted-foreground">
                   Context resets (clearing the window entirely) proved more

--- a/src/app/projects/mikrotik-config-gen/page.tsx
+++ b/src/app/projects/mikrotik-config-gen/page.tsx
@@ -44,12 +44,19 @@ export default function MikrotikConfigGenPage() {
             ISP technicians
           </p>
           <div className="flex gap-4">
-            <Link href="https://presentation.ncolesummers.com" target="_blank">
-              <Button variant="outline" className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              className="flex items-center gap-2"
+              asChild
+            >
+              <Link
+                href="https://presentation.ncolesummers.com"
+                target="_blank"
+              >
                 <UploadIcon className="h-4 w-4" />
                 View Presentation
-              </Button>
-            </Link>
+              </Link>
+            </Button>
           </div>
         </div>
 
@@ -381,15 +388,22 @@ app.Run()`}
             Interested in learning more?
           </h2>
           <div className="flex justify-center gap-4">
-            <Link href="https://presentation.ncolesummers.com" target="_blank">
-              <Button variant="outline" className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              className="flex items-center gap-2"
+              asChild
+            >
+              <Link
+                href="https://presentation.ncolesummers.com"
+                target="_blank"
+              >
                 <UploadIcon className="h-4 w-4" />
                 View Presentation
-              </Button>
-            </Link>
-            <Link href="/">
-              <Button variant="accent">Back to Portfolio</Button>
-            </Link>
+              </Link>
+            </Button>
+            <Button variant="accent" asChild>
+              <Link href="/">Back to Portfolio</Link>
+            </Button>
           </div>
         </section>
       </main>

--- a/src/app/projects/myui/page.tsx
+++ b/src/app/projects/myui/page.tsx
@@ -43,12 +43,16 @@ export default function MyUIPage() {
             services for the University of Idaho community
           </p>
           <div className="flex gap-4">
-            <Link href="https://my.uidaho.edu" target="_blank">
-              <Button variant="outline" className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              className="flex items-center gap-2"
+              asChild
+            >
+              <Link href="https://my.uidaho.edu" target="_blank">
                 <PlayIcon className="h-4 w-4" />
                 Visit MyUI
-              </Button>
-            </Link>
+              </Link>
+            </Button>
           </div>
         </div>
 
@@ -661,15 +665,19 @@ export default function MyUIPage() {
             Interested in learning more?
           </h2>
           <div className="flex justify-center gap-4">
-            <Link href="https://my.uidaho.edu" target="_blank">
-              <Button variant="outline" className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              className="flex items-center gap-2"
+              asChild
+            >
+              <Link href="https://my.uidaho.edu" target="_blank">
                 <PlayIcon className="h-4 w-4" />
                 Visit MyUI
-              </Button>
-            </Link>
-            <Link href="/">
-              <Button variant="accent">Back to Portfolio</Button>
-            </Link>
+              </Link>
+            </Button>
+            <Button variant="accent" asChild>
+              <Link href="/">Back to Portfolio</Link>
+            </Button>
           </div>
         </section>
       </main>

--- a/src/app/projects/profile-extractor/page.tsx
+++ b/src/app/projects/profile-extractor/page.tsx
@@ -680,9 +680,9 @@ validation_model = ChatGoogleGenerativeAI(
             Interested in similar solutions?
           </h2>
           <div className="flex justify-center gap-4">
-            <Link href="/">
-              <Button variant="accent">Back to Portfolio</Button>
-            </Link>
+            <Button variant="accent" asChild>
+              <Link href="/">Back to Portfolio</Link>
+            </Button>
           </div>
         </section>
       </main>

--- a/src/app/projects/uidaho-website/page.tsx
+++ b/src/app/projects/uidaho-website/page.tsx
@@ -81,12 +81,16 @@ export default function UIdahoWebsitePage() {
             Sitecore CMS, Next.js, TypeScript, and Azure cloud services
           </p>
           <div className="flex flex-wrap justify-center gap-4">
-            <Link href="https://www.uidaho.edu" target="_blank">
-              <Button variant="outline" className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              className="flex items-center gap-2"
+              asChild
+            >
+              <Link href="https://www.uidaho.edu" target="_blank">
                 <ExternalLink className="h-4 w-4" />
                 Visit Live Site
-              </Button>
-            </Link>
+              </Link>
+            </Button>
           </div>
 
           {/* Tech Stack Badges */}
@@ -379,15 +383,19 @@ export default function UIdahoWebsitePage() {
             discuss enterprise web development projects.
           </p>
           <div className="flex flex-wrap justify-center gap-4">
-            <Link href="https://www.uidaho.edu" target="_blank">
-              <Button variant="outline" className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              className="flex items-center gap-2"
+              asChild
+            >
+              <Link href="https://www.uidaho.edu" target="_blank">
                 <ExternalLink className="h-4 w-4" />
                 Visit uidaho.edu
-              </Button>
-            </Link>
-            <Link href="/#contact">
-              <Button variant="accent">Contact Me</Button>
-            </Link>
+              </Link>
+            </Button>
+            <Button variant="accent" asChild>
+              <Link href="/#contact">Contact Me</Link>
+            </Button>
           </div>
         </section>
       </main>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -34,5 +34,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "yearly",
       priority: 0.6,
     },
+    {
+      url: `${baseUrl}/projects/uidaho-website`,
+      lastModified: new Date(),
+      changeFrequency: "yearly",
+      priority: 0.6,
+    },
+    {
+      url: `${baseUrl}/projects/agent-development-lifecycle`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
   ];
 }

--- a/src/assets/adlc-architecture.svg
+++ b/src/assets/adlc-architecture.svg
@@ -1,0 +1,148 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 450" width="800" height="450">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 3.5 L 0 7" fill="none" stroke="#6b7280" stroke-width="1"/>
+    </marker>
+    <marker id="arrow-accent" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 3.5 L 0 7" fill="none" stroke="#3b82f6" stroke-width="1"/>
+    </marker>
+    <marker id="arrow-fail" viewBox="0 0 10 7" refX="9" refY="3.5" markerWidth="8" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 3.5 L 0 7" fill="none" stroke="#ef4444" stroke-width="1"/>
+    </marker>
+  </defs>
+
+  <!-- Background -->
+  <rect width="800" height="450" fill="#141414" rx="0"/>
+
+  <!-- Title -->
+  <text x="400" y="36" text-anchor="middle" fill="#fafafa" font-family="system-ui, -apple-system, sans-serif" font-size="14" font-weight="600" letter-spacing="0.05em">AGENT DEVELOPMENT LIFECYCLE</text>
+  <line x1="310" y1="46" x2="490" y2="46" stroke="#3b82f6" stroke-width="1" opacity="0.4"/>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- ORCHESTRATOR — top center -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="300" y="62" width="200" height="44" rx="6" fill="none" stroke="#3b82f6" stroke-width="1.5"/>
+  <text x="400" y="80" text-anchor="middle" fill="#fafafa" font-family="system-ui, -apple-system, sans-serif" font-size="13" font-weight="600">Orchestrator</text>
+  <text x="400" y="96" text-anchor="middle" fill="#6b7280" font-family="system-ui, -apple-system, sans-serif" font-size="9">state detection · agent dispatch</text>
+
+  <!-- Dispatch lines from orchestrator -->
+  <!-- To Initializer -->
+  <line x1="340" y1="106" x2="145" y2="150" stroke="#6b7280" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+  <!-- To Generator -->
+  <line x1="400" y1="106" x2="400" y2="150" stroke="#6b7280" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+  <!-- To Evaluator -->
+  <line x1="460" y1="106" x2="655" y2="150" stroke="#6b7280" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#arrow)"/>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- INITIALIZER — left -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="50" y="152" width="190" height="80" rx="6" fill="#1e1e1e" stroke="#2a2a2a" stroke-width="1"/>
+  <text x="145" y="175" text-anchor="middle" fill="#fafafa" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">Initializer</text>
+  <text x="145" y="194" text-anchor="middle" fill="#6b7280" font-family="system-ui, -apple-system, sans-serif" font-size="9">reads app_spec.txt</text>
+  <text x="145" y="207" text-anchor="middle" fill="#6b7280" font-family="system-ui, -apple-system, sans-serif" font-size="9">scaffolds project</text>
+  <text x="145" y="220" text-anchor="middle" fill="#6b7280" font-family="system-ui, -apple-system, sans-serif" font-size="9">generates feature list</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- GENERATOR — center -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="290" y="152" width="220" height="80" rx="6" fill="#1e1e1e" stroke="#3b82f6" stroke-width="1" opacity="1"/>
+  <text x="400" y="175" text-anchor="middle" fill="#3b82f6" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">Generator</text>
+  <text x="400" y="194" text-anchor="middle" fill="#6b7280" font-family="system-ui, -apple-system, sans-serif" font-size="9">one feature per session</text>
+  <text x="400" y="207" text-anchor="middle" fill="#6b7280" font-family="system-ui, -apple-system, sans-serif" font-size="9">commits code · updates progress</text>
+  <text x="400" y="220" text-anchor="middle" fill="#6b7280" font-family="system-ui, -apple-system, sans-serif" font-size="9">follows boot sequence</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- EVALUATOR — right -->
+  <!-- ═══════════════════════════════════════════ -->
+  <rect x="560" y="152" width="190" height="80" rx="6" fill="#1e1e1e" stroke="#2a2a2a" stroke-width="1"/>
+  <text x="655" y="175" text-anchor="middle" fill="#fafafa" font-family="system-ui, -apple-system, sans-serif" font-size="12" font-weight="600">Evaluator</text>
+  <text x="655" y="194" text-anchor="middle" fill="#6b7280" font-family="system-ui, -apple-system, sans-serif" font-size="9">tests running application</text>
+  <text x="655" y="207" text-anchor="middle" fill="#6b7280" font-family="system-ui, -apple-system, sans-serif" font-size="9">scores on 4 criteria</text>
+  <text x="655" y="220" text-anchor="middle" fill="#6b7280" font-family="system-ui, -apple-system, sans-serif" font-size="9">separated evaluation</text>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- FLOW ARROWS between agents -->
+  <!-- ═══════════════════════════════════════════ -->
+
+  <!-- Initializer → Generator -->
+  <line x1="240" y1="192" x2="288" y2="192" stroke="#6b7280" stroke-width="1" marker-end="url(#arrow)"/>
+
+  <!-- Generator → Evaluator -->
+  <line x1="510" y1="192" x2="558" y2="192" stroke="#3b82f6" stroke-width="1" marker-end="url(#arrow-accent)"/>
+
+  <!-- Evaluator fail → Generator (curved return path) -->
+  <path d="M 560 234 Q 400 274 290 234" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="5,3" marker-end="url(#arrow-fail)"/>
+  <text x="425" y="268" text-anchor="middle" fill="#ef4444" font-family="system-ui, -apple-system, sans-serif" font-size="8" font-weight="500" opacity="0.8">fail → revise</text>
+
+  <!-- Evaluator pass → Complete -->
+  <line x1="750" y1="192" x2="775" y2="192" stroke="#22c55e" stroke-width="1"/>
+  <circle cx="783" cy="192" r="6" fill="none" stroke="#22c55e" stroke-width="1"/>
+  <circle cx="783" cy="192" r="2.5" fill="#22c55e"/>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- JSON STATE FILES — middle row -->
+  <!-- ═══════════════════════════════════════════ -->
+  <text x="400" y="302" text-anchor="middle" fill="#6b7280" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="500" letter-spacing="0.08em">FILE-BASED STATE</text>
+  <line x1="320" y1="308" x2="480" y2="308" stroke="#2a2a2a" stroke-width="1"/>
+
+  <!-- feature_list.json -->
+  <rect x="88" y="320" width="150" height="36" rx="4" fill="#1a1a2e" stroke="#3b82f6" stroke-width="0.5" opacity="0.6"/>
+  <text x="100" y="335" fill="#3b82f6" font-family="ui-monospace, monospace" font-size="8" opacity="0.8">{}</text>
+  <text x="113" y="335" fill="#9ca3af" font-family="ui-monospace, monospace" font-size="9">feature_list.json</text>
+  <text x="163" y="348" text-anchor="middle" fill="#4b5563" font-family="system-ui, -apple-system, sans-serif" font-size="7">source of truth</text>
+
+  <!-- progress.json -->
+  <rect x="268" y="320" width="130" height="36" rx="4" fill="#1a1a2e" stroke="#3b82f6" stroke-width="0.5" opacity="0.6"/>
+  <text x="280" y="335" fill="#3b82f6" font-family="ui-monospace, monospace" font-size="8" opacity="0.8">{}</text>
+  <text x="293" y="335" fill="#9ca3af" font-family="ui-monospace, monospace" font-size="9">progress.json</text>
+  <text x="333" y="348" text-anchor="middle" fill="#4b5563" font-family="system-ui, -apple-system, sans-serif" font-size="7">institutional memory</text>
+
+  <!-- evaluation_report.json -->
+  <rect x="428" y="320" width="170" height="36" rx="4" fill="#1a1a2e" stroke="#3b82f6" stroke-width="0.5" opacity="0.6"/>
+  <text x="440" y="335" fill="#3b82f6" font-family="ui-monospace, monospace" font-size="8" opacity="0.8">{}</text>
+  <text x="453" y="335" fill="#9ca3af" font-family="ui-monospace, monospace" font-size="9">evaluation_report.json</text>
+  <text x="513" y="348" text-anchor="middle" fill="#4b5563" font-family="system-ui, -apple-system, sans-serif" font-size="7">quality gate</text>
+
+  <!-- plan.json -->
+  <rect x="628" y="320" width="110" height="36" rx="4" fill="#1a1a2e" stroke="#3b82f6" stroke-width="0.5" opacity="0.6"/>
+  <text x="640" y="335" fill="#3b82f6" font-family="ui-monospace, monospace" font-size="8" opacity="0.8">{}</text>
+  <text x="653" y="335" fill="#9ca3af" font-family="ui-monospace, monospace" font-size="9">plan.json</text>
+  <text x="683" y="348" text-anchor="middle" fill="#4b5563" font-family="system-ui, -apple-system, sans-serif" font-size="7">full product spec</text>
+
+  <!-- Dashed lines connecting files to agents -->
+  <line x1="163" y1="320" x2="145" y2="232" stroke="#2a2a2a" stroke-width="0.5" stroke-dasharray="2,2"/>
+  <line x1="333" y1="320" x2="400" y2="232" stroke="#2a2a2a" stroke-width="0.5" stroke-dasharray="2,2"/>
+  <line x1="513" y1="320" x2="655" y2="232" stroke="#2a2a2a" stroke-width="0.5" stroke-dasharray="2,2"/>
+
+  <!-- ═══════════════════════════════════════════ -->
+  <!-- STATE MACHINE — bottom -->
+  <!-- ═══════════════════════════════════════════ -->
+  <text x="400" y="390" text-anchor="middle" fill="#6b7280" font-family="system-ui, -apple-system, sans-serif" font-size="9" font-weight="500" letter-spacing="0.08em">ORCHESTRATOR STATE MACHINE</text>
+  <line x1="290" y1="396" x2="510" y2="396" stroke="#2a2a2a" stroke-width="1"/>
+
+  <!-- State nodes -->
+  <rect x="42" y="408" width="110" height="24" rx="12" fill="none" stroke="#3d3d3d" stroke-width="0.75"/>
+  <text x="97" y="424" text-anchor="middle" fill="#6b7280" font-family="ui-monospace, monospace" font-size="8">initialization</text>
+
+  <rect x="180" y="408" width="90" height="24" rx="12" fill="none" stroke="#3d3d3d" stroke-width="0.75"/>
+  <text x="225" y="424" text-anchor="middle" fill="#6b7280" font-family="ui-monospace, monospace" font-size="8">planning</text>
+
+  <rect x="298" y="408" width="100" height="24" rx="12" fill="none" stroke="#3b82f6" stroke-width="0.75"/>
+  <text x="348" y="424" text-anchor="middle" fill="#3b82f6" font-family="ui-monospace, monospace" font-size="8">generation</text>
+
+  <rect x="426" y="408" width="100" height="24" rx="12" fill="none" stroke="#3d3d3d" stroke-width="0.75"/>
+  <text x="476" y="424" text-anchor="middle" fill="#6b7280" font-family="ui-monospace, monospace" font-size="8">evaluation</text>
+
+  <rect x="554" y="408" width="90" height="24" rx="12" fill="none" stroke="#22c55e" stroke-width="0.75"/>
+  <text x="599" y="424" text-anchor="middle" fill="#22c55e" font-family="ui-monospace, monospace" font-size="8">complete</text>
+
+  <!-- State transition arrows -->
+  <line x1="152" y1="420" x2="178" y2="420" stroke="#3d3d3d" stroke-width="0.75" marker-end="url(#arrow)"/>
+  <line x1="270" y1="420" x2="296" y2="420" stroke="#3d3d3d" stroke-width="0.75" marker-end="url(#arrow)"/>
+  <line x1="398" y1="420" x2="424" y2="420" stroke="#3d3d3d" stroke-width="0.75" marker-end="url(#arrow)"/>
+  <line x1="526" y1="420" x2="552" y2="420" stroke="#3d3d3d" stroke-width="0.75" marker-end="url(#arrow)"/>
+
+  <!-- Evaluation → Generation loop indicator -->
+  <path d="M 438 432 Q 400 446 358 432" fill="none" stroke="#ef4444" stroke-width="0.75" stroke-dasharray="3,2" marker-end="url(#arrow-fail)"/>
+
+</svg>

--- a/src/components/contact-section.tsx
+++ b/src/components/contact-section.tsx
@@ -10,9 +10,9 @@ const ContactSection = () => {
         <p className="mb-8 text-sm sm:text-base md:text-lg text-muted-foreground">
           I&apos;m open to new opportunities and would love to hear from you.
         </p>
-        <a href="mailto:nate@ncolesummers.com">
-          <Button variant="accent">Contact me</Button>
-        </a>
+        <Button variant="accent" asChild>
+          <a href="mailto:nate@ncolesummers.com">Contact me</a>
+        </Button>
       </div>
     </section>
   );

--- a/src/components/project-grid.tsx
+++ b/src/components/project-grid.tsx
@@ -1,5 +1,6 @@
 import ProjectCard from "@/components/project-card";
 import { AnimatedCard } from "@/components/ui/animated-section";
+import adlcImage from "@/assets/adlc-architecture.svg";
 import profileExtractorImage from "@/assets/profile-extractor.png";
 import myuiImage from "@/assets/myui.png";
 import mikrotikConfigGenImage from "@/assets/mikrotik-config-gen.png";
@@ -12,13 +13,22 @@ const ProjectGrid = () => {
         <div className="grid gap-8 md:grid-cols-2">
           <AnimatedCard delay={0}>
             <ProjectCard
+              title="Enterprise Agent Development Lifecycle"
+              description="A TypeScript reference architecture for multi-agent autonomous coding systems built on Anthropic's Claude Agent SDK, synthesizing five Anthropic research documents."
+              link="/projects/agent-development-lifecycle"
+              image={adlcImage}
+              tags={["TypeScript", "Claude Agent SDK", "Multi-Agent"]}
+            />
+          </AnimatedCard>
+          <AnimatedCard delay={100}>
+            <ProjectCard
               title="University of Idaho Website"
               description="A modern redesign of the University of Idaho website built with Sitecore, Next.js, TypeScript, Storybook, and Azure services."
               link="/projects/uidaho-website"
               image={uidahoWebsiteImage}
             />
           </AnimatedCard>
-          <AnimatedCard delay={100}>
+          <AnimatedCard delay={200}>
             <ProjectCard
               title="AI Data Extraction Research"
               description="Research spike exploring the feasibility of using foundation models to extract faculty and staff profile data for the University of Idaho website."
@@ -26,7 +36,7 @@ const ProjectGrid = () => {
               image={profileExtractorImage}
             />
           </AnimatedCard>
-          <AnimatedCard delay={200}>
+          <AnimatedCard delay={300}>
             <ProjectCard
               title="MyUI"
               description="Lead developer for University of Idaho's modernized dashboard, creating custom React components to streamline student access to university services."
@@ -34,7 +44,7 @@ const ProjectGrid = () => {
               image={myuiImage}
             />
           </AnimatedCard>
-          <AnimatedCard delay={300}>
+          <AnimatedCard delay={400}>
             <ProjectCard
               title="Mikrotik Configuration Generator"
               description="A cross-platform desktop application that standardizes router configurations for ISP technicians, built with Go and Wails."

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -45,9 +45,7 @@ test.describe("Navigation", () => {
       await page.goto("/");
 
       await page.click("text=Enterprise Agent Development Lifecycle");
-      await expect(page).toHaveURL(
-        pageUrls.projects.agentDevelopmentLifecycle,
-      );
+      await expect(page).toHaveURL(pageUrls.projects.agentDevelopmentLifecycle);
       await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
     });
 

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -41,6 +41,16 @@ test.describe("Navigation", () => {
   });
 
   test.describe("Project Pages", () => {
+    test("should navigate to ADLC project", async ({ page }) => {
+      await page.goto("/");
+
+      await page.click("text=Enterprise Agent Development Lifecycle");
+      await expect(page).toHaveURL(
+        pageUrls.projects.agentDevelopmentLifecycle,
+      );
+      await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    });
+
     test("should navigate to MikroTik Config Generator project", async ({
       page,
     }) => {
@@ -74,6 +84,9 @@ test.describe("Navigation", () => {
 
     test("should handle direct project page access", async ({ page }) => {
       // Test direct navigation to project pages
+      await page.goto(pageUrls.projects.agentDevelopmentLifecycle);
+      await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
       await page.goto(pageUrls.projects.mikrotikConfigGen);
       await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
 

--- a/tests/fixtures/test-data.ts
+++ b/tests/fixtures/test-data.ts
@@ -42,6 +42,7 @@ export const pageUrls = {
   home: "/",
   about: "/about",
   projects: {
+    agentDevelopmentLifecycle: "/projects/agent-development-lifecycle",
     mikrotikConfigGen: "/projects/mikrotik-config-gen",
     myui: "/projects/myui",
     profileExtractor: "/projects/profile-extractor",


### PR DESCRIPTION
## Summary
- Add new project page for Enterprise Agent Development Lifecycle (ADLC) — a TypeScript reference architecture for multi-agent autonomous coding systems built on Anthropic's Claude Agent SDK
- Feature ADLC as the first project in the homepage grid, reflecting its technical depth and alignment with the portfolio's SDLC automation focus
- Fix sitemap by adding the previously missing `/projects/uidaho-website` route alongside the new ADLC route

## Changes
- **New:** `src/assets/adlc-architecture.svg` — Dark-themed SVG architecture diagram showing three-agent orchestration flow
- **New:** `src/app/projects/agent-development-lifecycle/page.tsx` — Full project detail page with sections on research foundation, architecture, technical implementation, context window strategy, and project validation
- **Modified:** `src/components/project-grid.tsx` — Added ADLC as first project card with tags
- **Modified:** `src/app/sitemap.ts` — Added ADLC and missing uidaho-website routes
- **Modified:** `tests/fixtures/test-data.ts` and `tests/e2e/navigation.spec.ts` — Added ADLC navigation and direct access tests

## Test plan
- [x] `pnpm lint` — zero errors
- [x] `pnpm build` — successful production build (753 B page size)
- [x] `pnpm format` — code formatted
- [x] `pnpm test:e2e` — 197 passed, 1 skipped (manual FormSpree test)
- [ ] Visual review of project card on homepage grid (dark + light mode)
- [ ] Visual review of project detail page (dark + light mode)
- [ ] Verify architecture diagram renders correctly at different viewport sizes
- [ ] Verify GitHub external link opens correctly
- [ ] Verify Back to Home navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)