### PR TITLE
docs(about): refresh copy — ten years experience, no em-dashes

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -90,7 +90,7 @@ export default function AboutPage() {
                 I&apos;m currently an Enterprise Applications Developer at the
                 University of Idaho, where I focus on integrating AI agents into
                 the software development lifecycle. With ten years of IT
-                experience and 5 years of application development, I build
+                experience and five years of application development, I build
                 systems that automate repetitive workflows while keeping
                 developers in control.
               </p>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -96,16 +96,15 @@ export default function AboutPage() {
               </p>
               <p className="mb-4 text-lg text-muted-foreground">
                 I&apos;ve been leveraging AI to accelerate software development
-                since the technical preview of GitHub Copilot in June 2021 —
-                long before the current wave of AI tooling. That early
-                experience shaped how I think about human-AI collaboration: what
-                to automate, what to leave to developers, and where the
-                boundaries should be.
+                since the technical preview of GitHub Copilot in June 2021, long
+                before the current wave of AI tooling. That early experience
+                shaped how I think about human-AI collaboration: what to
+                automate, what to leave to developers, and where the boundaries
+                should be.
               </p>
               <p className="text-lg text-muted-foreground">
-                I work across TypeScript, Python, Go, C#, and Rust — choosing
-                the right tool for each problem rather than defaulting to one
-                stack.
+                I work across TypeScript, Python, Go, C#, and Rust, choosing the
+                right tool for each problem rather than defaulting to one stack.
               </p>
             </div>
             <ContentCard>
@@ -170,12 +169,12 @@ export default function AboutPage() {
               <p className="mb-4 text-lg text-muted-foreground">
                 I believe the best AI-assisted workflows are the ones where
                 humans stay in the driver&apos;s seat. Automation should
-                eliminate toil, not judgment — freeing developers to focus on
+                eliminate toil, not judgment. It frees developers to focus on
                 architecture, design, and the decisions that matter.
               </p>
               <p className="mb-4 text-lg text-muted-foreground">
                 I&apos;m drawn to the intersection of AI-powered developer tools
-                and enterprise software — where automation can meaningfully
+                and enterprise software, where automation can meaningfully
                 reduce cycle time without sacrificing reliability or developer
                 trust.
               </p>
@@ -230,7 +229,8 @@ export default function AboutPage() {
               <h3 className="mb-2 text-xl font-semibold">Food & Music</h3>
               <p className="text-muted-foreground">
                 Can always be tempted away from work with the promise of good
-                food and live music—the perfect combination for recharging.
+                food and live music. It&apos;s the perfect combination for
+                recharging.
               </p>
             </ContentCard>
           </div>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -89,7 +89,7 @@ export default function AboutPage() {
               <p className="mb-4 text-lg text-muted-foreground">
                 I&apos;m currently an Enterprise Applications Developer at the
                 University of Idaho, where I focus on integrating AI agents into
-                the software development lifecycle. With 9 years of IT
+                the software development lifecycle. With ten years of IT
                 experience and 5 years of application development, I build
                 systems that automate repetitive workflows while keeping
                 developers in control.


### PR DESCRIPTION
## Summary
- Update IT experience on the About page from "9 years" to "ten years"
- Rewrite five paragraphs to remove em-dashes so the copy reads as deliberately human rather than AI-generated

## Test plan
- [ ] `pnpm lint` passes
- [ ] `pnpm build` succeeds
- [ ] Visually verify `/about` in dark + light themes — copy renders cleanly, no orphaned spaces or broken JSX
- [ ] `grep -n "—" src/app/about/page.tsx` returns no results
- [ ] Confirm Professional Journey, Philosophy & Approach, and Beyond the Code sections still read naturally after the rewrites

🤖 Generated with [Claude Code](https://claude.com/claude-code)