### PR TITLE
fix(figures): prevent FIG. 4 label collisions

### DIFF
--- a/docs/design/profile-extraction-parts.md
+++ b/docs/design/profile-extraction-parts.md
@@ -19,9 +19,9 @@ not a diagram of a production system and does not reproduce profile records.
 | Verification | The case study documents a validation step after extraction; `docs/REDESIGN_PLAN.md` requires a verification step and a checked answer. |
 
 The plate orders these parts exactly as the brief states: source pages →
-LangGraph extraction → structured profiles → verification. The words “checked
-answer” state that the question was evaluated; they do not publish a metric or
-claim a production outcome.
+LangGraph extraction → structured profiles → verification. The words “source
+check” state what the verification pass compared the output against; they do
+not publish a metric or claim a production outcome.
 
 ## Deliberately not drawn
 

--- a/src/components/figure-index.tsx
+++ b/src/components/figure-index.tsx
@@ -69,7 +69,7 @@ const figures: readonly Figure[] = [
     href: "/projects/profile-extractor",
     plate: <PlateProfileExtractor />,
     plateDescription:
-      "Source pages pass through a LangGraph extraction step into structured profiles, followed by verification. The research spike asked a feasibility question and checked the answer.",
+      "Source pages pass through a LangGraph extraction step into structured profiles, followed by verification against the source. The research spike asked a feasibility question and checked the output.",
   },
   {
     numeral: 5,

--- a/src/components/figures/index-plates.tsx
+++ b/src/components/figures/index-plates.tsx
@@ -144,7 +144,7 @@ export const PlateProfileExtractor = () => (
       LangGraph
     </text>
     <text className="fig-box-sub" x={118} y={104}>
-      extraction pass
+      extraction
     </text>
 
     <line className="fig-flow" x1={152} y1={91} x2={159} y2={91} />
@@ -180,7 +180,7 @@ export const PlateProfileExtractor = () => (
       Verification
     </text>
     <text className="fig-box-sub" x={275} y={104}>
-      checked answer
+      source check
     </text>
   </PlateFrame>
 );

--- a/tests/e2e/profile-extractor-index-plate.spec.ts
+++ b/tests/e2e/profile-extractor-index-plate.spec.ts
@@ -17,7 +17,7 @@ test.describe("FIG. 4 AI data extraction research index plate", () => {
     ).toBeVisible();
     await expect(
       semanticFigure.getByText(
-        "Source pages pass through a LangGraph extraction step into structured profiles, followed by verification. The research spike asked a feasibility question and checked the answer.",
+        "Source pages pass through a LangGraph extraction step into structured profiles, followed by verification against the source. The research spike asked a feasibility question and checked the output.",
         { exact: true },
       ),
     ).toBeAttached();
@@ -35,11 +35,11 @@ test.describe("FIG. 4 AI data extraction research index plate", () => {
       "Source",
       "pages",
       "LangGraph",
-      "extraction pass",
+      "extraction",
       "Structured",
       "profiles",
       "Verification",
-      "checked answer",
+      "source check",
     ]);
 
     for (const part of [
@@ -77,6 +77,74 @@ test.describe("FIG. 4 AI data extraction research index plate", () => {
     expect(allPlateText).not.toMatch(
       /name|email|phone|student|faculty|staff|production|scale|deployment/i,
     );
+  });
+
+  test("keeps every box description clear of its enclosing rule", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto("/");
+    await page.evaluate(() => document.fonts.ready.then(() => undefined));
+
+    const figure = page
+      .locator("article")
+      .filter({ has: page.getByText("FIG. 4", { exact: true }) });
+    const plate = figure.locator("svg.fig-plate");
+    const boxes = await plate.locator("rect.fig-box").evaluateAll(rects =>
+      rects.map(rect => {
+        const rule = rect.getBoundingClientRect();
+        const halfStroke =
+          Number.parseFloat(getComputedStyle(rect).strokeWidth) / 2;
+        const label = rect.nextElementSibling;
+        const description =
+          label?.nextElementSibling as SVGGraphicsElement | null;
+
+        if (
+          !label?.matches("text.fig-box-label") ||
+          !description?.matches("text.fig-box-sub")
+        ) {
+          throw new Error(
+            "Each FIG. 4 box must be followed by its label and description",
+          );
+        }
+
+        const text = description.getBoundingClientRect();
+
+        return {
+          part: rect.getAttribute("data-part"),
+          halfStroke,
+          rule: {
+            left: rule.left,
+            right: rule.right,
+            top: rule.top,
+            bottom: rule.bottom,
+          },
+          text: {
+            value: description.textContent,
+            left: text.left,
+            right: text.right,
+            top: text.top,
+            bottom: text.bottom,
+          },
+        };
+      }),
+    );
+
+    expect(boxes).toHaveLength(4);
+    for (const box of boxes) {
+      expect
+        .soft(box.text.left, `${box.part}: ${box.text.value} left`)
+        .toBeGreaterThanOrEqual(box.rule.left + box.halfStroke);
+      expect
+        .soft(box.text.right, `${box.part}: ${box.text.value} right`)
+        .toBeLessThanOrEqual(box.rule.right - box.halfStroke);
+      expect
+        .soft(box.text.top, `${box.part}: ${box.text.value} top`)
+        .toBeGreaterThanOrEqual(box.rule.top + box.halfStroke);
+      expect
+        .soft(box.text.bottom, `${box.part}: ${box.text.value} bottom`)
+        .toBeLessThanOrEqual(box.rule.bottom - box.halfStroke);
+    }
   });
 
   test("uses AA-contrast text and reproducible line weights in both media", async ({


### PR DESCRIPTION
## Summary

- Shorten FIG. 4 descriptions to extraction and source check.
- Align the accessible description and evidence inventory with source-backed verification.
- Add a stroke-aware mobile SVG containment regression.

## Root cause

The descriptions were wider than their enclosing boxes, while the existing responsive checks only verified containment of the overall plate and cell.

## Impact

FIG. 4 now preserves clear separation between its descriptions and box rules at the mobile viewport without changing the diagram structure.

## Validation

- pnpm run format:check
- pnpm run build
- Focused FIG. 4 Playwright suite: 30/30 across five browser projects
- Full E2E matrix by project: 428 passed, 2 expected mobile skips
- Visual inspection at 375px and 1440px in paper and blueprint themes
- git diff --check