### PR TITLE
fix(test): match the external 403 on every engine, not just Chromium

### DIFF
--- a/tests/e2e/runtime-health-fixture.spec.ts
+++ b/tests/e2e/runtime-health-fixture.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+import { isIgnorableExternalResourceConsoleError } from "../fixtures/runtime-health";
+
+/**
+ * The allowlist for blocked third-party requests used to compare against one
+ * exact string, which silently stopped matching on WebKit and failed ~50 tests
+ * with noise the fixture was written to ignore. These pin the phrasing each
+ * engine actually emits.
+ */
+test.describe("runtime health: ignorable external 403", () => {
+  test("ignores the 403 phrasing every engine emits", () => {
+    // Chromium and Firefox leave the reason phrase empty.
+    expect(
+      isIgnorableExternalResourceConsoleError(
+        "Failed to load resource: the server responded with a status of 403 ()",
+      ),
+    ).toBe(true);
+
+    // WebKit fills it in. This is the case that regressed.
+    expect(
+      isIgnorableExternalResourceConsoleError(
+        "Failed to load resource: the server responded with a status of 403 (Forbidden)",
+      ),
+    ).toBe(true);
+  });
+
+  test("still reports failures that are not an external 403", () => {
+    for (const text of [
+      "Failed to load resource: the server responded with a status of 404 ()",
+      "Failed to load resource: the server responded with a status of 500 (Internal Server Error)",
+      "Uncaught TypeError: undefined is not an object",
+      "",
+    ]) {
+      expect(isIgnorableExternalResourceConsoleError(text)).toBe(false);
+    }
+  });
+});

--- a/tests/fixtures/runtime-health.ts
+++ b/tests/fixtures/runtime-health.ts
@@ -6,11 +6,19 @@ export interface RuntimeHealth {
   sameOriginFailures: string[];
 }
 
+// Engines disagree on how they render the status text in this message:
+// Chromium and Firefox leave the parentheses empty, WebKit fills in the reason
+// phrase ("403 (Forbidden)"). Match the shape rather than one engine's exact
+// wording, or the allowlist silently stops applying on WebKit.
+//
+// Ignoring every 403 here is safe because it only suppresses console noise.
+// A same-origin 403 is still caught independently by the response handler in
+// observeRuntimeHealth and surfaces as a sameOriginFailure.
+const IGNORABLE_EXTERNAL_403 =
+  /^Failed to load resource: the server responded with a status of 403 \(.*\)$/;
+
 export function isIgnorableExternalResourceConsoleError(text: string) {
-  return (
-    text ===
-    "Failed to load resource: the server responded with a status of 403 ()"
-  );
+  return IGNORABLE_EXTERNAL_403.test(text);
 }
 
 export function observeRuntimeHealth(


### PR DESCRIPTION
Unblocks the red CI on #46 (and #47 stacked above it). One-line predicate change plus a regression spec.

## What broke

The allowlist for blocked third-party requests in `tests/fixtures/runtime-health.ts` compared against a single exact string:

```ts
text === "Failed to load resource: the server responded with a status of 403 ()"
```

Chromium and Firefox leave the reason phrase empty. WebKit fills it in — `403 (Forbidden)`. So the allowlist silently stopped applying on WebKit, and `expectRuntimeHealthClean` failed on exactly the noise it exists to ignore: ~50 failures across `loopworks-case-study.spec.ts` and `loopworks-deconstruction.spec.ts` in [run 30711918705](https://github.com/ncolesummers/enterprise-intelligence-portfolio/actions/runs/30711918705), all three retries, against a perfectly healthy product.

## Why it read as flaky

The suite **passes on WebKit locally** — the third-party request only 403s in CI. A test that fails only when an external request happens to be blocked presents identically to a flaky test, and invites a retry bump or a `workers` reduction instead of a fix. That pattern is the reason #48 exists.

## Why ignoring every 403 is still safe

This suppresses console noise only. A same-origin 403 is caught independently by the `response` handler in `observeRuntimeHealth` and reported as a `sameOriginFailure`, so real failures still fail. Only the matcher was wrong, not the design.

The helper is also used by `myui-case-study`, `mikrotik-case-study`, and `profile-extractor-case-study`, which were exposed to the same latent bug.

## Verification

- New spec pins both engines' phrasing, and was run against the **old** predicate first to confirm it fails there — a regression test that can't fail isn't one.
- `loopworks-case-study` + `loopworks-deconstruction` on WebKit: 24/24 pass.
- `pnpm lint` clean, `pnpm format` clean.

## After this lands

#46 and #47 need a rebase to pick it up; both should go green. Filed under #48, which tracks the broader audit — this fixes one concrete bug and does **not** address the concurrency flakiness that `workers: 1` was introduced to suppress. That remains open.

Refs #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)