### PR TITLE
Audit Playwright concurrency and qualify two workers

### DIFF
--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -71,6 +71,35 @@ expose races that had been latent:
   such a test is usually written to catch. Wait for `data-shown="true"` on the
   view before acting on anything inside it.
 
+A sixth hazard was reproduced during the issue #48 concurrency audit:
+
+- **A resolved set can still be transient.** Firefox exposed transient,
+  fully resolved colour sets when the suite ran in parallel. The social-link
+  contrast test failed in 6 of 20 four-worker repetitions, with ratios between
+  1.17:1 and 2.75:1; MyUI independently produced a 2.20:1 mixed-medium sample.
+  Read every compared colour in one `evaluate`, then use `readSettled` when the
+  read follows a medium switch and the set itself should remain unchanged. The
+  helper requires two consecutive resolved sets to agree. Keep `readResolved`
+  for reads that deliberately change state, such as focus and blur probes.
+
+## Concurrency Policy
+
+The suite runs with two workers locally and in CI. The earlier CI-only
+one-worker setting came from the initial Playwright scaffold; repository history
+does not contain a demonstrated concurrency failure that caused it.
+
+Issue #48 qualified two workers with retries disabled: one one-worker control
+passed in 5.8 minutes, the first two-worker run reproduced the Firefox contrast
+race, and the repaired suite then passed three consecutive full two-worker runs
+in 3.1 minutes each. A full four-worker stress run passed in 2.4 minutes, plus
+focused Firefox stress runs for contrast, themes, and scroll-driven figures.
+These are local measurements on 2026-08-01, not CI performance budgets.
+
+Use retries only for the configured CI diagnostic behavior, never to qualify a
+worker-count change. Reproduce a suspected race with a fresh server,
+`--retries=0`, and the same worker count before changing synchronization or
+lowering concurrency. See ADR 0003.
+
 The suite must prefer role- and name-based locators over styling or DOM-shape
 selectors. Removing a product behavior may remove its test, but surviving
 behavior needs an equally specific assertion; a looser assertion is not a
@@ -85,6 +114,10 @@ pnpm test:e2e
 # One suite or one browser while iterating
 pnpm exec playwright test tests/e2e/contact-link.spec.ts
 pnpm exec playwright test tests/e2e/contact-link.spec.ts --project=chromium
+
+# Concurrency diagnosis; repeat from a fresh server and keep retries disabled
+CI=true pnpm exec playwright test --workers=2 --retries=0
+CI=true pnpm exec playwright test --workers=4 --retries=0
 
 # Interactive debugging
 pnpm test:e2e:ui
@@ -112,7 +145,8 @@ and traces rather than accepting a flaky pass.
 ## CI
 
 Pull requests and protected-branch pushes install dependencies, lint, check
-formatting, build, install Playwright browsers, and run the full E2E suite.
+formatting, build, install Playwright browsers, and run the full E2E suite with
+two workers.
 Failed runs upload Playwright artifacts for diagnosis. The site has no contact
 form integration, scheduled email-delivery test, or third-party form endpoint.
 

--- a/docs/adr/0003-qualify-two-playwright-workers.md
+++ b/docs/adr/0003-qualify-two-playwright-workers.md
@@ -1,0 +1,54 @@
+# ADR 0003: Qualify two Playwright workers in CI
+
+- **Status:** Accepted
+- **Date:** 2026-08-01
+
+## Context
+
+Playwright was configured with one worker on CI and two locally. The one-worker
+CI setting existed in the initial test scaffold; history does not show that it
+was introduced in response to a measured concurrency failure. With 440 tests
+across five browser projects, the setting serialized work without an evidence
+record for the trade-off.
+
+A retry-free audit did expose real Firefox timing races above one worker. The
+social-link contrast test returned mixed-medium ratios as low as 1.17:1, and the
+MyUI case study independently returned 2.20:1. Both read fully resolved computed
+styles while a medium switch was still settling. The MyUI test also sampled the
+ground and foreground in separate browser evaluations.
+
+## Decision
+
+Run Playwright with two workers locally and in CI.
+
+Compared colour sets must be read in one browser evaluation. Stable sets sampled
+immediately after a medium switch use the shared `readSettled` helper, which
+requires two consecutive resolved reads to agree. Reads that intentionally
+change state continue to use `readResolved` and do not claim cross-poll
+stability.
+
+Worker-count changes are qualified with retries disabled. The acceptance record
+for this decision is:
+
+- one full one-worker control: 438 passed, 2 skipped, 5.8 minutes;
+- the original two-worker red: 437 passed, 1 failed, 2 skipped;
+- social-link Firefox stress before repair: 6 failed of 20;
+- three consecutive repaired two-worker runs: 438 passed and 2 skipped in 3.1
+  minutes each;
+- one repaired full four-worker stress run: 438 passed and 2 skipped in 2.4
+  minutes;
+- repaired focused stress: social contrast 20/20, MyUI themes 60/60, broader
+  Firefox themes 75/75, and Loopworks scroll behavior 50/50.
+
+All measurements were local on 2026-08-01 against fresh Turbopack development
+servers. They qualify test isolation and the two-worker setting; they are not a
+production performance budget.
+
+## Consequences
+
+- CI gains bounded parallelism without treating a retry-assisted pass as proof.
+- A future concurrency failure is investigated at the failing worker count with
+  retries disabled; lowering workers is an explicit policy rollback, not a
+  silent flake fix.
+- CI retries, the development-versus-production server choice, browser install
+  scope, and PR-versus-main project coverage remain separate issue #48 decisions.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,8 +11,8 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : 2,
+  /* Bound concurrency to the retry-free level qualified in ADR 0003. */
+  workers: 2,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.HTML_REPORT ? "html" : "list",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/tests/e2e/myui-case-study.spec.ts
+++ b/tests/e2e/myui-case-study.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { contrastRatio, readComputedColor } from "../fixtures/contrast";
+import { contrastRatio, readSettled } from "../fixtures/contrast";
 import { isIgnorableExternalResourceConsoleError } from "../fixtures/runtime-health";
 
 const route = "/projects/myui";
@@ -195,20 +195,20 @@ test.describe("MyUI case study", () => {
       );
       expect(transitionDuration).toBeLessThanOrEqual(0.001);
 
-      const readContrast = async () => ({
-        background: await readComputedColor(
-          page.locator("body"),
-          "backgroundColor",
-        ),
-        body: await readComputedColor(
-          page
-            .getByTestId("case-study-section")
-            .first()
-            .locator(".type-body")
-            .first(),
-          "color",
-        ),
-      });
+      const readContrast = () =>
+        readSettled(
+          () =>
+            page.locator("body").evaluate(root => {
+              const bodyCopy = root.querySelector(
+                '[data-testid="case-study-section"] .type-body',
+              );
+              return {
+                background: getComputedStyle(root).backgroundColor,
+                body: bodyCopy ? getComputedStyle(bodyCopy).color : "",
+              };
+            }),
+          value => [value.background, value.body],
+        );
 
       await expect(page.locator("html")).not.toHaveClass(/dark/);
       const paper = await readContrast();

--- a/tests/e2e/social-icons-accessibility.spec.ts
+++ b/tests/e2e/social-icons-accessibility.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Locator, type Page } from "@playwright/test";
 
-import { contrastRatio, readResolved } from "../fixtures/contrast";
+import { contrastRatio, readSettled } from "../fixtures/contrast";
 import {
   expectReducedMotionTransition,
   expectRuntimeHealthClean,
@@ -80,14 +80,15 @@ async function expectSocialContract(
  * references are sampled after and come back blueprint chalk. Chalk on paper is
  * 1.1:1, so the assertion fails loudly on a pair that never existed on screen.
  * A stale colour is fully resolved, so polling for resolution cannot catch it —
- * only sampling the set together can, which is what `readResolved` is for.
+ * only sampling the set together and waiting for it to settle can, which is
+ * what `readSettled` is for.
  *
  * Selected by `aria-label` inside the evaluate because a Playwright locator
  * cannot cross into it. That is still name-based selection, not DOM shape.
  */
 async function expectSocialContrast(page: Page, surfaces: Locator[]) {
   for (const surface of surfaces) {
-    const sample = await readResolved(
+    const sample = await readSettled(
       () =>
         surface.evaluate(
           (root, names) => ({

--- a/tests/fixtures/contrast.ts
+++ b/tests/fixtures/contrast.ts
@@ -8,11 +8,12 @@ import { expect, type Locator } from "@playwright/test";
  * fixture and none of them learned that an unresolved colour is a thing that
  * happens. They now import from here, so a gap closed once is closed everywhere.
  *
- * Two ways to read a colour, and the difference matters. `readComputedColor` is
- * for a single value. `readResolved` wraps a read that returns several at once,
- * so the set is consistent with itself — polling each colour separately can
- * straddle a medium switch and measure a paper foreground against a blueprint
- * ground, which is a wrong answer rather than a flaky one.
+ * Three ways to read a colour, and the difference matters. `readComputedColor`
+ * is for a single value. `readResolved` wraps a read that returns several at
+ * once, so the set is consistent with itself — polling each colour separately
+ * can straddle a medium switch and measure a paper foreground against a
+ * blueprint ground, which is a wrong answer rather than a flaky one.
+ * `readSettled` adds a stability check for sets read after a medium switch.
  *
  * Computed colors arrive in whatever syntax the browser chooses to serialize,
  * which is why every branch below exists.
@@ -94,6 +95,40 @@ export const readResolved = async <T>(
       return colors(value).some(isUnresolvedColor);
     })
     .toBe(false);
+  return value;
+};
+
+/**
+ * Read a resolved colour set after a medium switch has stopped recalculating.
+ *
+ * Firefox can expose an intermediate style snapshot under parallel load even
+ * when the whole set is read in one evaluate. Requiring two consecutive
+ * identical sets guards against sampling that transition. Keep this separate
+ * from `readResolved`: callers that intentionally change focus while reading
+ * do not have a stable set.
+ */
+export const readSettled = async <T>(
+  read: () => Promise<T>,
+  colors: (value: T) => string[],
+) => {
+  let value!: T;
+  let previousColors: string[] | undefined;
+  await expect
+    .poll(async () => {
+      value = await read();
+      const currentColors = colors(value);
+      if (currentColors.some(isUnresolvedColor)) {
+        previousColors = undefined;
+        return false;
+      }
+
+      const isStable =
+        previousColors?.length === currentColors.length &&
+        previousColors.every((color, index) => color === currentColors[index]);
+      previousColors = currentColors;
+      return isStable;
+    })
+    .toBe(true);
   return value;
 };
 


### PR DESCRIPTION
## Summary

- reproduce the retry-free Playwright failure above one worker
- stabilize Firefox theme-contrast sampling without weakening WCAG assertions
- qualify and configure two workers locally and in CI
- record the evidence and rollback policy in the test plan and ADR 0003

## Root cause

The CI-only one-worker setting came from the initial Playwright scaffold; repository history does not show a measured concurrency failure that introduced it.

The audit did reproduce real Firefox races under parallel load. Contrast checks could observe transient but fully resolved computed-style snapshots during a theme switch. The MyUI check also read its foreground and background in separate browser evaluations. The repair samples compared colors atomically and requires stable reads only where the state is expected to remain unchanged.

## Validation

Red evidence:

- initial two-worker full run: 437 passed, 1 failed, 2 skipped
- Firefox social contrast stress: 6 failures in 20 repetitions
- independent MyUI mixed-medium contrast failure: 2.20:1

Green evidence:

- three consecutive retry-free two-worker full runs: 438 passed, 2 skipped
- retry-free four-worker full stress: 438 passed, 2 skipped
- focused Firefox stress: social 20/20, MyUI 60/60, broader themes 75/75, scroll behavior 50/50
- final committed-tree configured run: 438 passed, 2 skipped in 3.1 minutes
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
- adversarial QA: no blocker or weakened accessibility coverage

## Scope

This is the concurrency-first slice of #48. CI retry policy, development-versus-production server choice, browser installation scope, and PR-versus-main browser coverage remain separate decisions in the issue.