### PR TITLE
docs(about): explain planning in public

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -158,6 +158,13 @@ export default function AboutPage() {
                 them off and no urgent path around them.
               </p>
               <p>
+                When the work can be public, the plan should be public too.
+                Publishing intent before implementation exposes assumptions and
+                tradeoffs while they can still be challenged. Keeping the
+                decisions and the result inspectable creates a record that is
+                stronger than a claim made after the fact.
+              </p>
+              <p>
                 I believe in blameless postmortems for the same reason. A system
                 that punishes the person who found the failure stops being told
                 about failures.

--- a/tests/e2e/about-page.spec.ts
+++ b/tests/e2e/about-page.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import {
+  expectRuntimeHealthClean,
+  observeRuntimeHealth,
+  type RuntimeHealth,
+} from "../fixtures/runtime-health";
+import { pageUrls } from "../fixtures/test-data";
+
+const runtimeByPage = new WeakMap<Page, RuntimeHealth>();
+
+test.beforeEach(({ page, baseURL }) => {
+  if (!baseURL) throw new Error("Playwright baseURL is required");
+  runtimeByPage.set(page, observeRuntimeHealth(page, baseURL));
+});
+
+test.afterEach(async ({ page }) => {
+  await page.waitForTimeout(50);
+  expectRuntimeHealthClean(runtimeByPage.get(page)!);
+});
+
+test.describe("About page", () => {
+  test("explains why public work begins with a public plan", async ({
+    page,
+  }) => {
+    await page.goto(pageUrls.about);
+
+    const howIWork = page.getByTestId("case-study-section").filter({
+      has: page.getByRole("heading", {
+        level: 2,
+        name: "How I Work",
+        exact: true,
+      }),
+    });
+
+    await expect(howIWork).toHaveCount(1);
+    await expect(
+      howIWork.getByText(
+        "When the work can be public, the plan should be public too. Publishing intent before implementation exposes assumptions and tradeoffs while they can still be challenged. Keeping the decisions and the result inspectable creates a record that is stronger than a claim made after the fact.",
+        { exact: true },
+      ),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- add a focused paragraph to the About page explaining why public work should begin with a public plan
- scope the principle to work that can safely be public, preserving the University of Idaho confidentiality boundary
- add a dedicated Playwright contract for the approved copy and runtime health

## TDD evidence

Red was captured before the production edit:

```
CI=true volta run --node 24.14.0 -- corepack pnpm@10.26.1 exec playwright test tests/e2e/about-page.spec.ts --project=chromium --retries=0
```

The test reached `/about` and failed because the exact paragraph was absent. After the minimal paragraph was added, the same command passed, followed by a retry-free 5/5 desktop/mobile browser matrix.

## Review gates

- two independent adversarial reviewers were asked to argue against merge; neither found a code-level blocker
- editorial review confirmed the wording protects the employer boundary, makes no unsupported outcome claim, and keeps the book inspiration-only
- QA review confirmed branch provenance, narrow diff scope, runtime-health coverage, and responsive/theme evidence
- Impeccable audit: **20/20**, implementation integrity pass, no P0-P3 findings
  - Accessibility 4/4
  - Performance 4/4
  - Theming 4/4
  - Responsive Design 4/4
  - Implementation Integrity 4/4

## Validation

- `pnpm format`
- `pnpm format:check`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm build`
- focused About contract: 5/5 across Chromium, Firefox, WebKit, Mobile Chrome, and Mobile Safari, retries disabled
- PAPER and BLUEPRINT at 390px, 768px, and 1440px
- 200% text scaling and reduced motion with zero horizontal overflow
- focused WCAG 2.1 A/AA checks in both media: zero violations
- final full Playwright gate: **453 passed, 2 skipped, 0 failed** at two workers with retries disabled
